### PR TITLE
Fix method signature returning a signed value instead of an unsigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added classes for [Point2](SDLTooSharp/Managed/Common/Point2.cs) and [Point2F](SDLTooSharp/Managed/Common/Point2.cs).
 - Added classes for [Size](SDLTooSharp/Managed/Common/Size.cs) and [SizeF](SDLTooSharp/Managed/Common/Size.cs).
 
+### Fixed
+- Fixed `SDL_GameControllerGetAxis` which returned an unsigned value instead of a signed one. 
+
 ## [0.2.0] - 2022-09-25
 ### Added
 - Added missing function `SDL_LoadWAV`.

--- a/SDLTooSharp/Bindings/SDL2/GameController.cs
+++ b/SDLTooSharp/Bindings/SDL2/GameController.cs
@@ -197,7 +197,7 @@ public static partial class SDL
     public static extern bool SDL_GameControllerHasAxis(IntPtr gameController, SDL_GameControllerAxis axis);
 
     [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
-    public static extern ushort SDL_GameControllerGetAxis(IntPtr gameController, SDL_GameControllerAxis axis);
+    public static extern short SDL_GameControllerGetAxis(IntPtr gameController, SDL_GameControllerAxis axis);
 
     public enum SDL_GameControllerButton
     {


### PR DESCRIPTION
`SDL_GameControllerGetAxis` should be returning a `Sint16` (`short`) instead of an `Uint16`(`ushort`)