### PR TITLE
Refactor SDLSurface into Interface and Add Mocking Test

### DIFF
--- a/SDLTooSharp/Managed/Font/IFont.cs
+++ b/SDLTooSharp/Managed/Font/IFont.cs
@@ -5,5 +5,5 @@ namespace SDLTooSharp.Managed.Font;
 
 public interface IFont
 {
-    public SDLSurface RenderGlyphLCD(uint glyph, Color foreground, Color background);
+    public ISurface RenderGlyphLCD(uint glyph, Color foreground, Color background);
 }

--- a/SDLTooSharp/Managed/Video/Renderer/SDLSoftwareRenderer.cs
+++ b/SDLTooSharp/Managed/Video/Renderer/SDLSoftwareRenderer.cs
@@ -11,13 +11,13 @@ public class SDLSoftwareRenderer : SDLRenderer
     /// <summary>
     /// A pointer to the surface
     /// </summary>
-    public SDLSurface Surface { get; protected set; }
+    public ISurface Surface { get; protected set; }
 
     /// <summary>
     /// Creates a new SoftwareRenderer
     /// </summary>
     /// <param name="surface"></param>
-    public SDLSoftwareRenderer(SDLSurface surface)
+    public SDLSoftwareRenderer(ISurface surface)
     {
         RendererPtr = SDL.SDL_CreateSoftwareRenderer(surface.SurfacePtr);
         if ( RendererPtr == IntPtr.Zero )

--- a/SDLTooSharp/Managed/Video/Surface/ISurface.cs
+++ b/SDLTooSharp/Managed/Video/Surface/ISurface.cs
@@ -1,4 +1,6 @@
+using SDLTooSharp.Bindings.SDL2;
 using SDLTooSharp.Managed.Common;
+using SDLTooSharp.Managed.Exception.Video.Surface;
 
 namespace SDLTooSharp.Managed.Video.Surface;
 /// <summary>
@@ -6,10 +8,36 @@ namespace SDLTooSharp.Managed.Video.Surface;
 /// </summary>
 public interface ISurface
 {
+    /// <summary>
+    /// Gets a value that indicates the dimensions of the surface
+    /// </summary>
     public Size Dimensions { get; }
+    
+    /// <summary>
+    /// Gets a value that indicates the pitch of the surface
+    /// (i.e. how many pixels there are per row)
+    /// </summary>
     public int Pitch { get; }
+    
+    /// <summary>
+    /// Gets a value that indicates the pointer where the surface's pixels exist
+    /// </summary>
     public IntPtr Pixels { get; }
-
+    
+    /// <summary>
+    /// Gets a value that indicates whether the surface is locked (and thus you can write to its pixels)
+    /// </summary>
+    public bool IsLocked { get; }
+    /// <summary>
+    /// Gets or sets a value that indicates the Surface's color key.
+    /// </summary>
+    /// <remarks>For implementation details, check <see cref="SDL.SDL_GetColorKey">SDL_GetColorKey</see>,
+    /// <see cref="SDL.SDL_HasColorKey">HasColorKey</see> and <see cref="SDL.SDL_SetColorKey">SetColorKey</see>
+    /// </remarks>
+    /// <exception cref="UnableToGetSurfaceColorKeyException">In case we cannot get the surface color key</exception>
+    /// <exception cref="UnableToSetSurfaceColorKeyException">In case we cannot set the surface color key</exception>
+    public Color? ColorKey { get; set; }
+    
     public void Lock();
     public void Unlock();
 

--- a/SDLTooSharp/Managed/Video/Surface/ISurface.cs
+++ b/SDLTooSharp/Managed/Video/Surface/ISurface.cs
@@ -3,31 +3,37 @@ using SDLTooSharp.Managed.Common;
 using SDLTooSharp.Managed.Exception.Video.Surface;
 
 namespace SDLTooSharp.Managed.Video.Surface;
+
 /// <summary>
 /// Interface for surfaces
 /// </summary>
-public interface ISurface
+public interface ISurface : IDisposable
 {
+    /// <summary>
+    /// Gets the actual pointer to an <see cref="SDLTooSharp.Bindings.SDL2.SDL.SDL_Surface"/> structure
+    /// </summary>
+    public IntPtr SurfacePtr { get; init; }
     /// <summary>
     /// Gets a value that indicates the dimensions of the surface
     /// </summary>
     public Size Dimensions { get; }
-    
+
     /// <summary>
     /// Gets a value that indicates the pitch of the surface
     /// (i.e. how many pixels there are per row)
     /// </summary>
     public int Pitch { get; }
-    
+
     /// <summary>
     /// Gets a value that indicates the pointer where the surface's pixels exist
     /// </summary>
     public IntPtr Pixels { get; }
-    
+
     /// <summary>
     /// Gets a value that indicates whether the surface is locked (and thus you can write to its pixels)
     /// </summary>
     public bool IsLocked { get; }
+
     /// <summary>
     /// Gets or sets a value that indicates the Surface's color key.
     /// </summary>
@@ -37,9 +43,64 @@ public interface ISurface
     /// <exception cref="UnableToGetSurfaceColorKeyException">In case we cannot get the surface color key</exception>
     /// <exception cref="UnableToSetSurfaceColorKeyException">In case we cannot set the surface color key</exception>
     public Color? ColorKey { get; set; }
-    
+
+    /// <summary>
+    /// Gets or sets a value that indicates a color value that gets multiplied into blit operations
+    /// </summary>
+    /// <remarks>
+    /// For implementation details see <see cref="SDL.SDL_GetSurfaceColorMod">SDL_GetSurfaceColorMod</see> and
+    /// <see cref="SDL.SDL_SetSurfaceColorMod">SDL_SetSurfaceColorMod</see>
+    /// </remarks>
+    /// <exception cref="UnableToGetSurfaceColorModException">In case we are not able to get the surface's color mod</exception>
+    /// <exception cref="UnableToSetSurfaceColorModException">In case we are not able to set the surface's color mod</exception>
+
+    public Color? ColorMod { get; set; }
+
+    /// <summary>
+    /// Set up a surface for directly accessing the pixels.
+    /// </summary>
+    /// <exception cref="UnableToLockSurfaceException"></exception>
     public void Lock();
+
+    /// <summary>
+    /// Release a surface after directly accessing the pixels.
+    /// </summary>
     public void Unlock();
 
+    /// <summary>
+    /// Sets or gets a value which indicates the alpha component to be multiplied in blit operations
+    /// </summary>
+    /// <remarks>For implementation details check <see cref="SDL.SDL_GetSurfaceAlphaMod"/>
+    /// and <see cref="SDL.SDL_SetSurfaceAlphaMod"/></remarks>
+    /// <exception cref="UnableToGetSurfaceAlphaModException"/>
+    /// <exception cref="UnableToSetSurfaceAlphaModException"/>
+    public byte AlphaMod { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value that indicates the surface's blend mode.
+    /// </summary>
+    /// <exception cref="UnableToGetSurfaceBlendModeException"></exception>
+    /// <exception cref="UnableToSetSurfaceBlendModeException"></exception>
+    public SDL.SDL_BlendMode BlendMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value which indicates whether the surface is RLE-enabled.
+    /// </summary>
+    /// <exception cref="UnableToSetRLEException"></exception>
+    public bool RLE { get; set; }
+
+    /// <summary>
+    /// Duplicates the current surface
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="UnableToDuplicateSurfaceException"></exception>
+    public ISurface Duplicate();
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="format"></param>
+    /// <returns></returns>
+    /// <exception cref="UnableToConvertSurfaceException"></exception>
+    public ISurface Convert(uint format);
 }

--- a/SDLTooSharp/Managed/Video/Surface/SDLSurface.cs
+++ b/SDLTooSharp/Managed/Video/Surface/SDLSurface.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using SDLTooSharp.Bindings.SDL2;
 using SDLTooSharp.Bindings.SDL2Image;
@@ -9,6 +10,7 @@ namespace SDLTooSharp.Managed.Video.Surface;
 /// <summary>
 /// Class for SDL Surface
 /// </summary>
+[ExcludeFromCodeCoverage]
 public partial class SDLSurface : ISurface, IDisposable
 {
     /// <summary>
@@ -17,42 +19,25 @@ public partial class SDLSurface : ISurface, IDisposable
     public IntPtr SurfacePtr { get; protected set; }
 
     private Size _dimensions;
-
-    /// <summary>
-    /// Gets a value that indicates the dimensions of the surface
-    /// </summary>
+    /// <inheritdoc cref="Dimensions"/>
     public Size Dimensions => _dimensions;
 
     private int _pitch;
 
-    /// <summary>
-    /// Gets a value that indicates the pitch of the surface
-    /// (i.e. how many pixels there are per row)
-    /// </summary>
+    /// <inheritdoc cref="Pitch"/>
     public int Pitch => _pitch;
 
     private IntPtr _pixelPtr;
 
-    /// <summary>
-    /// Gets a value that indicates the pointer where the surface's pixels exist
-    /// </summary>
+    /// <inheritdoc cref="Pixels"/>
     public IntPtr Pixels => _pixelPtr;
 
     private bool _locked;
 
-    /// <summary>
-    /// Gets a value that indicates whether the surface is locked (and thus you can write to its pixels)
-    /// </summary>
+    /// <inheritdoc cref="IsLocked"/>
     public bool IsLocked => _locked;
 
-    /// <summary>
-    /// Gets or sets a value that indicates the Surface's color key.
-    /// </summary>
-    /// <remarks>For implementation details, check <see cref="SDL.SDL_GetColorKey">SDL_GetColorKey</see>,
-    /// <see cref="SDL.SDL_HasColorKey">HasColorKey</see> and <see cref="SDL.SDL_SetColorKey">SetColorKey</see>
-    /// </remarks>
-    /// <exception cref="UnableToGetSurfaceColorKeyException">In case we cannot get the surface color key</exception>
-    /// <exception cref="UnableToSetSurfaceColorKeyException">In case we cannot set the surface color key</exception>
+    /// <inheritdoc cref="ColorKey"/>
     public Color? ColorKey
     {
         get {

--- a/SDLTooSharp/Managed/Video/Surface/SDLSurface.cs
+++ b/SDLTooSharp/Managed/Video/Surface/SDLSurface.cs
@@ -11,14 +11,13 @@ namespace SDLTooSharp.Managed.Video.Surface;
 /// Class for SDL Surface
 /// </summary>
 [ExcludeFromCodeCoverage]
-public partial class SDLSurface : ISurface, IDisposable
+public partial class SDLSurface : ISurface
 {
-    /// <summary>
-    /// Gets the actual pointer to an <see cref="SDLTooSharp.Bindings.SDL2.SDL.SDL_Surface"/> structure
-    /// </summary>
-    public IntPtr SurfacePtr { get; protected set; }
+    /// <inheritdoc cref="SurfacePtr"/>
+    public IntPtr SurfacePtr { get; init; }
 
     private Size _dimensions;
+
     /// <inheritdoc cref="Dimensions"/>
     public Size Dimensions => _dimensions;
 
@@ -68,15 +67,7 @@ public partial class SDLSurface : ISurface, IDisposable
         }
     }
 
-    /// <summary>
-    /// Gets or sets a value that indicates a color value that gets multiplied into blit operations
-    /// </summary>
-    /// <remarks>
-    /// For implementation details see <see cref="SDL.SDL_GetSurfaceColorMod">SDL_GetSurfaceColorMod</see> and
-    /// <see cref="SDL.SDL_SetSurfaceColorMod">SDL_SetSurfaceColorMod</see>
-    /// </remarks>
-    /// <exception cref="UnableToGetSurfaceColorModException">In case we are not able to get the surface's color mod</exception>
-    /// <exception cref="UnableToSetSurfaceColorModException">In case we are not able to set the surface's color mod</exception>
+    /// <inheritdoc cref="ColorMod"/>
     public Color? ColorMod
     {
         get {
@@ -99,13 +90,7 @@ public partial class SDLSurface : ISurface, IDisposable
         }
     }
 
-    /// <summary>
-    /// Sets or gets a value which indicates the alpha component to be multiplied in blit operations
-    /// </summary>
-    /// <remarks>For implementation details check <see cref="SDL.SDL_GetSurfaceAlphaMod"/>
-    /// and <see cref="SDL.SDL_SetSurfaceAlphaMod"/></remarks>
-    /// <exception cref="UnableToGetSurfaceAlphaModException"/>
-    /// <exception cref="UnableToSetSurfaceAlphaModException"/>
+    /// <inheritdoc cref="AlphaMod"/>
     public byte AlphaMod
     {
         get {
@@ -126,11 +111,7 @@ public partial class SDLSurface : ISurface, IDisposable
         }
     }
 
-    /// <summary>
-    /// Gets or sets a value that indicates the surface's blend mode.
-    /// </summary>
-    /// <exception cref="UnableToGetSurfaceBlendModeException"></exception>
-    /// <exception cref="UnableToSetSurfaceBlendModeException"></exception>
+    /// <inheritdoc cref="BlendMode"/>
     public SDL.SDL_BlendMode BlendMode
     {
         get {
@@ -151,10 +132,7 @@ public partial class SDLSurface : ISurface, IDisposable
         }
     }
 
-    /// <summary>
-    /// Gets or sets a value which indicates whether the surface is RLE-enabled.
-    /// </summary>
-    /// <exception cref="UnableToSetRLEException"></exception>
+    /// <inheritdoc cref="RLE"/>
     public bool RLE
     {
         get => SDL.SDL_HasSurfaceRLE(SurfacePtr);
@@ -170,9 +148,7 @@ public partial class SDLSurface : ISurface, IDisposable
     }
 
 
-    /// <summary>
-    /// Set up a surface for directly accessing the pixels.
-    /// </summary>
+    /// <inheritdoc cref="Lock"/>
     public void Lock()
     {
         if ( _locked )
@@ -189,9 +165,7 @@ public partial class SDLSurface : ISurface, IDisposable
         _locked = true;
     }
 
-    /// <summary>
-    /// Release a surface after directly accessing the pixels.
-    /// </summary>
+    /// <inheritdoc cref="Unlock"/>
     public void Unlock()
     {
         if ( !_locked )
@@ -305,14 +279,12 @@ public partial class SDLSurface : ISurface, IDisposable
         {
             throw new UnableToCreateSurfaceException();
         }
+
         InitializeSurface();
     }
 
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <returns></returns>
-    public SDLSurface Duplicate()
+    /// <inheritdoc cref="Duplicate"/>
+    public ISurface Duplicate()
     {
         IntPtr surfacePtr = SDL.SDL_DuplicateSurface(SurfacePtr);
         if ( surfacePtr == IntPtr.Zero )
@@ -323,12 +295,8 @@ public partial class SDLSurface : ISurface, IDisposable
         return new SDLSurface(surfacePtr);
     }
 
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="format"></param>
-    /// <returns></returns>
-    public SDLSurface Convert(uint format)
+    /// <inheritdoc cref="Convert"/>
+    public ISurface Convert(uint format)
     {
         IntPtr surfacePtr = SDL.SDL_ConvertSurfaceFormat(SurfacePtr, format, 0);
         if ( surfacePtr == IntPtr.Zero )
@@ -345,10 +313,10 @@ public partial class SDLSurface : ISurface, IDisposable
     /// <param name="format"></param>
     /// <returns></returns>
     /// <exception cref="NotImplementedException"></exception>
-    public SDLSurface Covnert(IntPtr format) =>
+    public ISurface Covnert(IntPtr format) =>
         throw new NotImplementedException("SDL_ConvertSurface is not implemented");
 
-    public static SDLSurface FromImageFile(string file)
+    public static ISurface FromImageFile(string file)
     {
         if ( !File.Exists(file) )
         {

--- a/SDLTooSharp/Managed/Video/Texture/SDLTexture.cs
+++ b/SDLTooSharp/Managed/Video/Texture/SDLTexture.cs
@@ -13,7 +13,7 @@ public class SDLTexture : IDisposable
 
     public SDLRenderer Renderer { get; protected init; }
 
-    public SDLTexture(SDLRenderer renderer, SDLSurface surface)
+    public SDLTexture(SDLRenderer renderer, ISurface surface)
     {
         TexturePtr = SDL.SDL_CreateTextureFromSurface(
             renderer.RendererPtr,
@@ -143,13 +143,7 @@ public class SDLTexture : IDisposable
             throw new FileNotFoundException("File not found", filename);
         }
 
-        var surfacePtr = SDLImage.IMG_Load(filename);
-        if ( surfacePtr == IntPtr.Zero )
-        {
-            throw new UnableToCreateTextureException();
-        }
-
-        var surface = new SDLSurface(surfacePtr);
+        var surface = SDLSurface.FromImageFile(filename);
 
         var newSurface = surface.Convert((uint)SDL.SDL_PixelFormatEnum.SDL_PIXELFORMAT_RGBA8888);
         surface.Dispose();

--- a/TooSharpTests/Managed/Font/FontTest.cs
+++ b/TooSharpTests/Managed/Font/FontTest.cs
@@ -17,15 +17,18 @@ public class FontTest
         Color fg = new Color(0, 0, 0);
         Color bg = new Color(0, 0, 0);
 
-        var surface = new SDLSurface(
-            new Size(1, 1),
-            SurfaceDepth.Depth32BitPerPixel,
-            SDL.SDL_PixelFormatEnum.SDL_PIXELFORMAT_RGBA8888
-        );
-
         var mock = new Mock<IFont>();
-        mock.Setup(x => x.RenderGlyphLCD(glyph, fg, bg)).Returns(surface);
+        mock.Setup(x => x.RenderGlyphLCD(glyph, fg, bg))
+            .Returns(() => {
+                var srf = new SDLSurface(
+                    new Size(1, 2),
+                    SurfaceDepth.Depth1BitPerPixel,
+                    SDL.SDL_PixelFormatEnum.SDL_PIXELFORMAT_BGR24);
 
-        Assert.Equal(surface, mock.Object.RenderGlyphLCD(glyph, fg, bg));
+                return srf;
+            });
+
+        var o = mock.Object.RenderGlyphLCD(glyph, fg, bg);
+        Assert.IsType<SDLSurface>(o);
     }
 }

--- a/TooSharpTests/Managed/Managed/Video/SurfaceTest.cs
+++ b/TooSharpTests/Managed/Managed/Video/SurfaceTest.cs
@@ -1,0 +1,142 @@
+using System.Diagnostics.CodeAnalysis;
+using Moq;
+using SDLTooSharp.Managed.Common;
+using SDLTooSharp.Managed.Exception.Video.Surface;
+using SDLTooSharp.Managed.Video.Surface;
+
+namespace TooSharpTests.Managed.Managed.Video;
+
+[ExcludeFromCodeCoverage]
+public class SurfaceTest
+{
+    [Fact]
+    public void TestGetDimensions()
+    {
+        var dimensions = new Size(100, 100);
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.Dimensions)
+            .Returns(dimensions);
+
+        Assert.Equal(dimensions, surfaceMock.Object.Dimensions);
+    }
+
+    [Fact]
+    public void TestGetPitch()
+    {
+        int pitch = 100;
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.Pitch)
+            .Returns(pitch);
+
+        Assert.Equal(pitch, surfaceMock.Object.Pitch);
+    }
+
+    [Fact]
+    public void TestGetPixelPointer()
+    {
+        IntPtr pixelPtr = IntPtr.Zero;
+        var surfaceMock = new Mock<ISurface>();
+
+        surfaceMock.SetupGet(x => x.Pixels)
+            .Returns(pixelPtr);
+
+        Assert.Equal(pixelPtr, surfaceMock.Object.Pixels);
+    }
+
+    [Fact]
+    public void TestIsLocked()
+    {
+        var surfaceMock = new Mock<ISurface>();
+
+        surfaceMock.Setup(x => x.Lock());
+        surfaceMock.SetupGet(x => x.IsLocked)
+            .Returns(true);
+
+        surfaceMock.Object.Lock();
+        Assert.True(surfaceMock.Object.IsLocked);
+    }
+
+    [Fact]
+    public void TestUnlock()
+    {
+        var surfaceMock = new Mock<ISurface>();
+
+        surfaceMock.Setup(x => x.Unlock());
+        surfaceMock.SetupGet(x => x.IsLocked)
+            .Returns(false);
+
+        surfaceMock.Object.Unlock();
+        Assert.False(surfaceMock.Object.IsLocked);
+    }
+
+    [Fact]
+    public void TestHasColorKey()
+    {
+        Color key = new Color(255, 0, 255);
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.ColorKey)
+            .Returns(key);
+
+        Assert.Equal(key, surfaceMock.Object.ColorKey);
+    }
+
+    [Fact]
+    public void TestDoesNotHaveColorKey()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.ColorKey)
+            .Returns(() => null);
+
+        Assert.Null(surfaceMock.Object.ColorKey);
+    }
+
+    [Fact]
+    public void TestCannotRetrieveColorKey()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.ColorKey)
+            .Throws<UnableToGetSurfaceColorKeyException>();
+
+        Assert.Throws<UnableToGetSurfaceColorKeyException>(
+            () => {
+                Color? objectColorKey = surfaceMock.Object.ColorKey;
+            });
+    }
+
+    [Fact]
+    public void TestSetColorKey()
+    {
+        Color key = new Color(0, 0, 0);
+        Color expected = new Color(255, 0, 255);
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupSet(x => x.ColorKey = expected).Callback<Color>(v => key = v);
+
+        surfaceMock.Object.ColorKey = expected;
+        Assert.Equal(expected, key);
+    }
+
+    [Fact]
+    public void TestUnsetColorKey()
+    {
+        Color key = new Color(255, 0, 255);
+        Color? expected = new Color(255, 0, 255);
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock
+            .SetupSet(x => x.ColorKey = null)
+            .Callback<Color?>(v => expected = v);
+
+        surfaceMock.Object.ColorKey = null;
+        Assert.Null(expected);
+    }
+
+    [Fact]
+    public void TestCannotSetColorKey()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupSet(x => x.ColorKey = null)
+            .Throws<UnableToSetSurfaceColorKeyException>();
+
+        Assert.Throws<UnableToSetSurfaceColorKeyException>(
+            () => { surfaceMock.Object.ColorKey = null; });
+    }
+}

--- a/TooSharpTests/Managed/Managed/Video/SurfaceTest.cs
+++ b/TooSharpTests/Managed/Managed/Video/SurfaceTest.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Moq;
+using SDLTooSharp.Bindings.SDL2;
 using SDLTooSharp.Managed.Common;
 using SDLTooSharp.Managed.Exception.Video.Surface;
 using SDLTooSharp.Managed.Video.Surface;
@@ -67,6 +68,16 @@ public class SurfaceTest
 
         surfaceMock.Object.Unlock();
         Assert.False(surfaceMock.Object.IsLocked);
+    }
+
+    [Fact]
+    public void TestUnableToLock()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.Setup(x => x.Lock())
+            .Throws<UnableToLockSurfaceException>();
+
+        Assert.Throws<UnableToLockSurfaceException>(() => surfaceMock.Object.Lock());
     }
 
     [Fact]
@@ -138,5 +149,259 @@ public class SurfaceTest
 
         Assert.Throws<UnableToSetSurfaceColorKeyException>(
             () => { surfaceMock.Object.ColorKey = null; });
+    }
+
+    [Fact]
+    public void GetColorMod()
+    {
+        var mod = new Color(255, 255, 255);
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.ColorMod)
+            .Returns(mod);
+
+        Assert.Equal(mod, surfaceMock.Object.ColorMod);
+    }
+
+    [Fact]
+    public void UnableToGetColorMod()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.ColorMod)
+            .Throws<UnableToGetSurfaceColorModException>();
+
+        Assert.Throws<UnableToGetSurfaceColorModException>(() => {
+            var color = surfaceMock.Object.ColorMod;
+        });
+    }
+
+    [Fact]
+    public void SetColorMod()
+    {
+        var mod = new Color(0, 222, 255);
+        var expected = new Color(0, 0, 0);
+
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupSet(x => x.ColorMod = mod)
+            .Callback<Color>(v => expected = v);
+
+        surfaceMock.Object.ColorMod = mod;
+        Assert.Equal(expected, mod);
+    }
+
+    [Fact]
+    public void ResetColorMod()
+    {
+        var mod = new Color(255, 255, 255);
+
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupSet(x => x.ColorMod = It.IsAny<Color?>());
+        surfaceMock.SetupGet(x => x.ColorMod)
+            .Returns(mod);
+
+        surfaceMock.Object.ColorMod = null;
+        Assert.Equal(mod, surfaceMock.Object.ColorMod);
+    }
+
+    [Fact]
+    public void UnableToSetColorMod()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupSet(x => x.ColorMod = It.IsAny<Color?>())
+            .Throws<UnableToSetSurfaceColorModException>();
+
+        Assert.Throws<UnableToSetSurfaceColorModException>(
+            () => surfaceMock.Object.ColorMod = null);
+    }
+
+    [Fact]
+    public void GetAlphaMod()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.AlphaMod)
+            .Returns(192);
+
+        Assert.Equal(192, surfaceMock.Object.AlphaMod);
+    }
+
+    [Fact]
+    public void UnableToGetAlphaMod()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.AlphaMod)
+            .Throws<UnableToGetSurfaceAlphaModException>();
+
+        Assert.Throws<UnableToGetSurfaceAlphaModException>(
+            () => {
+                byte mod = surfaceMock.Object.AlphaMod;
+            });
+    }
+
+    [Fact]
+    public void SetAlphaMod()
+    {
+        byte expected = 0;
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupSet(x => x.AlphaMod = It.IsAny<byte>())
+            .Callback<byte>(x => expected = x);
+
+        surfaceMock.Object.AlphaMod = 192;
+        Assert.Equal(192, expected);
+    }
+
+    [Fact]
+    public void UnableToSetAlphaMod()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupSet(x => x.AlphaMod = It.IsAny<byte>())
+            .Throws<UnableToSetSurfaceAlphaModException>();
+
+        Assert.Throws<UnableToSetSurfaceAlphaModException>(
+            () => surfaceMock.Object.AlphaMod = 192);
+    }
+
+    [Fact]
+    public void GetBlendMode()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.BlendMode)
+            .Returns(SDL.SDL_BlendMode.SDL_BLENDMODE_ADD);
+
+        Assert.Equal(SDL.SDL_BlendMode.SDL_BLENDMODE_ADD, surfaceMock.Object.BlendMode);
+    }
+
+    [Fact]
+    public void UnableToGetBlendMode()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.BlendMode)
+            .Throws<UnableToGetSurfaceBlendModeException>();
+
+        Assert.Throws<UnableToGetSurfaceBlendModeException>(
+            () => {
+                var mode = surfaceMock.Object.BlendMode;
+            });
+    }
+
+    [Fact]
+    public void SetBlendMode()
+    {
+        var mode = SDL.SDL_BlendMode.SDL_BLENDMODE_NONE;
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupSet(x => x.BlendMode = It.IsAny<SDL.SDL_BlendMode>())
+            .Callback<SDL.SDL_BlendMode>(v => mode = v);
+
+        surfaceMock.Object.BlendMode = SDL.SDL_BlendMode.SDL_BLENDMODE_MOD;
+        Assert.Equal(SDL.SDL_BlendMode.SDL_BLENDMODE_MOD, mode);
+    }
+
+    [Fact]
+    public void UnableToSetBlendMode()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupSet(x => x.BlendMode = It.IsAny<SDL.SDL_BlendMode>())
+            .Throws<UnableToSetSurfaceBlendModeException>();
+
+        Assert.Throws<UnableToSetSurfaceBlendModeException>(
+            () => surfaceMock.Object.BlendMode = SDL.SDL_BlendMode.SDL_BLENDMODE_ADD);
+    }
+
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GetRle(bool rle)
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupGet(x => x.RLE)
+            .Returns(rle);
+
+        Assert.Equal(rle, surfaceMock.Object.RLE);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SetRle(bool rle)
+    {
+        bool? expected = null;
+        var surfaceMock = new Mock<ISurface>();
+
+        surfaceMock.SetupSet(x => x.RLE = It.IsAny<bool>())
+            .Callback<bool>(v => expected = v);
+
+        surfaceMock.Object.RLE = rle;
+        Assert.Equal(expected, rle);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void UnableToSetRle(bool rle)
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.SetupSet(x => x.RLE = It.IsAny<bool>())
+            .Throws(() => new UnableToSetRLEException(rle));
+
+        Assert.Throws<UnableToSetRLEException>(() => surfaceMock.Object.RLE = rle);
+    }
+
+    [Fact]
+    public void DuplicateSurface()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.Setup(x => x.Duplicate())
+            .Returns(() => {
+                var srf = new SDLSurface(
+                    new Size(1, 2),
+                    SurfaceDepth.Depth1BitPerPixel,
+                    SDL.SDL_PixelFormatEnum.SDL_PIXELFORMAT_BGR24);
+
+                return srf;
+            });
+
+        var surface = surfaceMock.Object.Duplicate();
+        Assert.IsType<SDLSurface>(surface);
+    }
+
+    [Fact]
+    public void UnableToDuplicate()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.Setup(x => x.Duplicate())
+            .Throws<UnableToDuplicateSurfaceException>();
+
+        Assert.Throws<UnableToDuplicateSurfaceException>(() => {
+            var surface = surfaceMock.Object.Duplicate();
+        });
+    }
+
+    [Fact]
+    public void ConvertSurface()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.Setup(x => x.Convert(1234))
+            .Returns(() => {
+                var srf = new SDLSurface(
+                    new Size(1, 2),
+                    SurfaceDepth.Depth1BitPerPixel,
+                    SDL.SDL_PixelFormatEnum.SDL_PIXELFORMAT_BGR24);
+
+                return srf;
+            });
+
+        var surface = surfaceMock.Object.Convert(1234);
+        Assert.IsType<SDLSurface>(surface);
+    }
+
+    [Fact]
+    public void UnableToConvertSurface()
+    {
+        var surfaceMock = new Mock<ISurface>();
+        surfaceMock.Setup(x => x.Convert(1234))
+            .Throws<UnableToConvertSurfaceException>();
+
+        Assert.Throws<UnableToConvertSurfaceException>(() => {
+            var surface = surfaceMock.Object.Convert(1234);
+        });
     }
 }


### PR DESCRIPTION
This PR is an attempt at moving the entire functionality of SDLSurface, into the ISurface interface, in order to write actual tests that Mock the Interface and document the logic. Since the SDLSurface class is coupled with actual SDL function, actual unit testing is impossible.

This will help in future refactorings.